### PR TITLE
Potential fix for code scanning alert no. 2: Reflected server-side cross-site scripting

### DIFF
--- a/apps/organizations/views.py
+++ b/apps/organizations/views.py
@@ -1,9 +1,10 @@
 # apps/organizations/views.py
 
 from django.http import HttpResponse
+from django.utils.html import escape
 
 def organization_list_view(request):
     return HttpResponse("Organization List Placeholder")
 
 def organization_detail_view(request, org_id):
-    return HttpResponse(f"Detail of Organization ID: {org_id}")
+    return HttpResponse(f"Detail of Organization ID: {escape(org_id)}")


### PR DESCRIPTION
Potential fix for [https://github.com/ioannisioannides/scopewatch/security/code-scanning/2](https://github.com/ioannisioannides/scopewatch/security/code-scanning/2)

To fix the problem, we need to escape the `org_id` before including it in the HTTP response. In Django, we can use the `django.utils.html.escape` function to properly escape any special characters in the `org_id` to prevent XSS attacks.

- Import the `escape` function from `django.utils.html`.
- Use the `escape` function to sanitize the `org_id` before including it in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the display of organization details by sanitizing identifiers, helping prevent potential injection vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->