### PR TITLE
Potential fix for code scanning alert no. 1: Reflected server-side cross-site scripting

### DIFF
--- a/apps/certification_bodies/views.py
+++ b/apps/certification_bodies/views.py
@@ -1,9 +1,10 @@
 # apps/certification_bodies/views.py
 
 from django.http import HttpResponse
+from django.utils.html import escape
 
 def certbody_list_view(request):
     return HttpResponse("Cert Bodies Placeholder")
 
 def certbody_detail_view(request, cb_id):
-    return HttpResponse(f"Detail of Certification Body ID: {cb_id}")
+    return HttpResponse(f"Detail of Certification Body ID: {escape(cb_id)}")


### PR DESCRIPTION
Potential fix for [https://github.com/ioannisioannides/scopewatch/security/code-scanning/1](https://github.com/ioannisioannides/scopewatch/security/code-scanning/1)

To fix the problem, we need to ensure that the `cb_id` value is properly escaped before being included in the HTTP response. This can be done using Django's built-in escaping functions. Specifically, we can use `django.utils.html.escape` to escape the `cb_id` value.

The best way to fix the problem without changing existing functionality is to import the `escape` function from `django.utils.html` and use it to escape `cb_id` before including it in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the display of certification body details by sanitizing identifier data, ensuring that any potentially unsafe characters are safely handled before rendering.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->